### PR TITLE
Fix multi-word vs single word react regex

### DIFF
--- a/scripts/react.js
+++ b/scripts/react.js
@@ -264,7 +264,7 @@ function start(robot) {
 
   var hubotMessageRegex = new RegExp('^[@]?(' + robot.name + ')' + (robot.alias ? '|(' + robot.alias + ')' : '') + '[:,]?\\s', 'i');
 
-  robot.respond(/react (([^\s]*)|"([^"]*)") (.*)/i, function(msg) {
+  robot.respond(/react (([^"\s]*)|"([^"]*)") (.*)/i, function(msg) {
     var term = msg.match[2] || msg.match[3];
     var response = msg.match[4];
 


### PR DESCRIPTION
Previously a multi word react string would be matched by the single word regex because " wasn't ignored in the first capture group. This change ensures that either a single unquoted word is matched OR a quoted multi-word phrase is matched.
