### PR TITLE
Improve Regex and Fix Support for Multi-word reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Train hubot to react to certain terms. Multiple responses to the same term are allowed. One will be selected at-random.
 
 ```
-Bob: hubot react homestar seriously.
+Bob: hubot react to "homestar" with "seriously".
 Hubot: reacting to homestar with seriously.
 ...
 Alice: Homestar Runner is the best.
@@ -47,7 +47,7 @@ HUBOT_REACT_INIT_TIMEOUT=N
 Tell hubot to react with `<response>` when it hears `<term>`.
 
 ```
-hubot react <term> <response>
+hubot react to "<term>" with "<response>"
 ```
 
 #### React (multi-word term)
@@ -55,7 +55,7 @@ hubot react <term> <response>
 Tell hubot to react with `<response>` when it hears `<term>`.
 
 ```
-hubot react "<term>" <response>
+hubot react to "<term>" with "<response>"
 ```
 
 #### Ignore

--- a/scripts/react.js
+++ b/scripts/react.js
@@ -264,7 +264,7 @@ function start(robot) {
 
   var hubotMessageRegex = new RegExp('^[@]?(' + robot.name + ')' + (robot.alias ? '|(' + robot.alias + ')' : '') + '[:,]?\\s', 'i');
 
-  robot.respond(/react "([^"]*)" (.*)/i, function(msg) {
+  robot.respond(/react to "([^"]*)" with "(.*)"/i, function(msg) {
     var term = msg.match[1];
     var response = msg.match[2];
 

--- a/scripts/react.js
+++ b/scripts/react.js
@@ -264,9 +264,9 @@ function start(robot) {
 
   var hubotMessageRegex = new RegExp('^[@]?(' + robot.name + ')' + (robot.alias ? '|(' + robot.alias + ')' : '') + '[:,]?\\s', 'i');
 
-  robot.respond(/react (([^\s]*)|"([^"]*)") (.*)/i, function(msg) {
-    var term = msg.match[2] || msg.match[3];
-    var response = msg.match[4];
+  robot.respond(/react "([^"]*)" (.*)/i, function(msg) {
+    var term = msg.match[1];
+    var response = msg.match[2];
 
     var responseObj = add(term, response);
 


### PR DESCRIPTION
This is just a small change to the regex used to parse terms and responses. It fixes #10 , #4 and potentially #11 .

I always found it very awkward and unfriendly writing "react <term> <response>" because there was no clear separation between the term and response except for whitespace. So I propose that we change it to a more readable and distinct format:

hubot react to "<term>" with "<response>"