### PR TITLE
Bump msgpack version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "underscore": "~1.7.0",
     "natural": "~0.1.28",
     "moment": "~2.8.3",
-    "msgpack": "~0.2.4"
+    "msgpack": "~1.0.2"
   }
 }


### PR DESCRIPTION
The msgpack Node module is regrettably criminally underdocumented, especially with regards to a change log. However, https://github.com/msgpack/msgpack/blob/master/spec.md states that the msgpack spec was last modified 2013, and npm says that 0.2.7 (what we previously used) was published in 2015. 1.x being compatible with 0.2.7 seems like a reasonable guess since the spec didn't change in the intervening time.

Therefore, bump msgpack to a post-1.x release. This probably fixes lots of install breakage as well as allowing automatic semver-compatible upgrades.